### PR TITLE
Remove spaces from require

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ copied from http://c2journal.com/2014/07/30/gulp-pipe-callback/
 Usage
 -----
 ```
-var gcallback = require(' gulp-callback ')
+var gcallback = require('gulp-callback');
  
 gulp.src(' ... ')
   .pipe(concat(" ... "))


### PR DESCRIPTION
Spaces break the require. One less step for the dev using this plugin.
